### PR TITLE
Add ability to configure Header section

### DIFF
--- a/pyelmer/elmer.py
+++ b/pyelmer/elmer.py
@@ -7,6 +7,7 @@ Each of these objects contains the data required in the sif in form
 of a dictionary called data.
 """
 
+import os
 import yaml
 
 
@@ -21,6 +22,10 @@ class Simulation:
 
     def __init__(self):
         self.intro_text = ""
+        self.header = {
+            "CHECK KEYWORDS": '"Warn"',
+            "Mesh DB": '"." "."',
+        }
         self.materials = {}
         self.bodies = {}
         self.boundaries = {}
@@ -31,18 +36,20 @@ class Simulation:
         self.constants = {"Stefan Boltzmann": 5.6704e-08}
         self.settings = {}
 
-    def write_sif(self, simulation_dir):
+    def write_sif(self, simulation_dir, filename="case.sif"):
         """Write sif file.
 
         Args:
             simulation_dir (str): Path of simulation directory
         """
         self._set_ids()
-        with open(simulation_dir + "/case.sif", "w") as f:
+        with open(os.path.join(simulation_dir, filename), "w") as f:
             if self.intro_text != "":
                 f.write(self.intro_text)
                 f.write("\n\n")
-            f.write("""Header\n  CHECK KEYWORDS "Warn"\n  Mesh DB "." "."\nEnd\n\n""")
+            f.write("Header\n")
+            f.write(self._dict_to_str(self.header, key_value_separator=" "))
+            f.write("End\n\n")
             f.write("Simulation\n")
             f.write(self._dict_to_str(self.settings))
             f.write("End\n\n")
@@ -115,10 +122,10 @@ class Simulation:
         with open(simulation_dir + "/boundaries.yml", "w") as f:
             yaml.dump(data, f, sort_keys=False)
 
-    def _dict_to_str(self, dictionary):
+    def _dict_to_str(self, dictionary, *, key_value_separator=" = "):
         text = ""
         for key, value in dictionary.items():
-            text = "".join([text, "  ", key, " = ", str(value), "\n"])
+            text = "".join([text, "  ", key, key_value_separator, str(value), "\n"])
         return text
 
     def _set_ids(self):
@@ -508,7 +515,7 @@ def load_body_force(name, simulation, setup_file=""):
         BodyForce object.
     """
     if setup_file == "":
-        setup_file = f"{data_dir}/body_forces.yml"
+        setup_file = os.path.join(data_dir, "body_forces.yml")
     with open(setup_file) as f:
         data = yaml.safe_load(f)[name]
     return BodyForce(simulation, name, data)

--- a/pyelmer/elmer.py
+++ b/pyelmer/elmer.py
@@ -35,15 +35,16 @@ class Simulation:
         self.equations = {}
         self.constants = {"Stefan Boltzmann": 5.6704e-08}
         self.settings = {}
+        self.sif_filename = "case.sif"
 
-    def write_sif(self, simulation_dir, filename="case.sif"):
+    def write_sif(self, simulation_dir):
         """Write sif file.
 
         Args:
             simulation_dir (str): Path of simulation directory
         """
         self._set_ids()
-        with open(os.path.join(simulation_dir, filename), "w") as f:
+        with open(os.path.join(simulation_dir, self.sif_filename), "w") as f:
             if self.intro_text != "":
                 f.write(self.intro_text)
                 f.write("\n\n")
@@ -108,8 +109,9 @@ class Simulation:
         Args:
             simulation_dir (str): simulation directory
         """
-        with open(simulation_dir + "/ELMERSOLVER_STARTINFO", "w") as f:
-            f.write("case.sif\n")
+        with open(os.path.join(simulation_dir, "ELMERSOLVER_STARTINFO"), "w") as f:
+            f.write(self.sif_filename)
+            f.write("\n")
 
     def write_boundary_ids(self, simulation_dir):
         """Write yaml-file containing the boundary names and the


### PR DESCRIPTION
Hello! We (also @db434) would like the ability to change the `Header` section of the SIF file that is generated (e.g. mesh & results locations).

This PR:
* Adds a `header` dictionary to the `Simulation` class which stores parameters
* Slightly expands the tests, such that the files stored in git are now used as a reference, and we check for exact matching against them. (This seemed the simplest way to check for unexpected regressions more generally)
* Adds a `sif_filename` property to the `Simulation` class, so that we can write to a different filename when needed.

Would appreciate your thoughts & feedback, thanks!