### PR TITLE
Allow duplicate Materials, Solvers, etc. to be added

### DIFF
--- a/pyelmer/elmer.py
+++ b/pyelmer/elmer.py
@@ -121,7 +121,7 @@ class Simulation:
             simulation_dir (str): Path of simulation directory
         """
         data = {boundary.id: name for name, boundary in self.boundaries.items()}
-        with open(os.path.join(simulation_dir + "/boundaries.yml"), "w") as f:
+        with open(os.path.join(simulation_dir, "boundaries.yml"), "w") as f:
             yaml.dump(data, f, sort_keys=False)
 
     def _dict_to_str(self, dictionary, *, key_value_separator=" = "):

--- a/pyelmer/elmer.py
+++ b/pyelmer/elmer.py
@@ -151,6 +151,18 @@ class Simulation:
 class Body:
     """Wrapper for bodies in sif-file."""
 
+    def __new__(cls, simulation, name, body_ids=None, data=None):
+        """Intercept object construction to return an existing object if possible."""
+        if name in simulation.bodies:
+            existing = simulation.bodies[name]
+            new_body_ids = [] if body_ids is None else body_ids
+            new_data = {} if data is None else data
+            if [new_body_ids, new_data] != [existing.body_ids, existing.data]:
+                raise ValueError(f'Body name clash: "{name}".')
+            return existing
+        else:
+            return super().__new__(cls)
+
     def __init__(self, simulation, name, body_ids=None, data=None):
         """Create body object.
 
@@ -209,6 +221,18 @@ class Body:
 class Boundary:
     """Wrapper for boundaries in sif-file."""
 
+    def __new__(cls, simulation, name, geo_ids=None, data=None):
+        """Intercept object construction to return an existing object if possible."""
+        if name in simulation.boundaries:
+            existing = simulation.boundaries[name]
+            new_geo_ids = [] if geo_ids is None else geo_ids
+            new_data = {} if data is None else data
+            if [new_geo_ids, new_data] != [existing.geo_ids, existing.data]:
+                raise ValueError(f'Boundary name clash: "{name}".')
+            return existing
+        else:
+            return super().__new__(cls)
+
     def __init__(self, simulation, name, geo_ids=None, data=None):
         """Create boundary object.
 
@@ -248,6 +272,17 @@ class Boundary:
 class Material:
     """Wrapper for materials in sif-file."""
 
+    def __new__(cls, simulation, name, data=None):
+        """Intercept object construction to return an existing object if possible."""
+        if name in simulation.materials:
+            existing = simulation.materials[name]
+            new_data = {} if data is None else data
+            if new_data != existing.data:
+                raise ValueError(f'Material name clash: "{name}".')
+            return existing
+        else:
+            return super().__new__(cls)
+
     def __init__(self, simulation, name, data=None):
         """Create material object
 
@@ -276,6 +311,17 @@ class Material:
 class BodyForce:
     """Wrapper for body forces in sif-file."""
 
+    def __new__(cls, simulation, name, data=None):
+        """Intercept object construction to return an existing object if possible."""
+        if name in simulation.body_forces:
+            existing = simulation.body_forces[name]
+            new_data = {} if data is None else data
+            if new_data != existing.data:
+                raise ValueError(f'BodyForce name clash: "{name}".')
+            return existing
+        else:
+            return super().__new__(cls)
+
     def __init__(self, simulation, name, data=None):
         """Create body force object.
 
@@ -303,6 +349,17 @@ class BodyForce:
 
 class InitialCondition:
     """Wrapper for initial condition in sif-file."""
+
+    def __new__(cls, simulation, name, data=None):
+        """Intercept object construction to return an existing object if possible."""
+        if name in simulation.initial_conditions:
+            existing = simulation.initial_conditions[name]
+            new_data = {} if data is None else data
+            if new_data != existing.data:
+                raise ValueError(f'InitialCondition name clash: "{name}".')
+            return existing
+        else:
+            return super().__new__(cls)
 
     def __init__(self, simulation, name, data=None):
         """Create initial condition object.
@@ -333,6 +390,17 @@ class InitialCondition:
 class Solver:
     """Wrapper for solver in sif-file."""
 
+    def __new__(cls, simulation, name, data=None):
+        """Intercept object construction to return an existing object if possible."""
+        if name in simulation.solvers:
+            existing = simulation.solvers[name]
+            new_data = {} if data is None else data
+            if new_data != existing.data:
+                raise ValueError(f'Solver name clash: "{name}".')
+            return existing
+        else:
+            return super().__new__(cls)
+
     def __init__(self, simulation, name, data=None):
         """Create solver object
 
@@ -360,6 +428,17 @@ class Solver:
 
 class Equation:
     """Wrapper for equations in sif-file."""
+
+    def __new__(cls, simulation, name, solvers, data=None):
+        """Intercept object construction to return an existing object if possible."""
+        if name in simulation.equations:
+            existing = simulation.equations[name]
+            new_data = {} if data is None else data
+            if [solvers, new_data] != [existing.solvers, existing.data]:
+                raise ValueError(f'Equation name clash: "{name}".')
+            return existing
+        else:
+            return super().__new__(cls)
 
     def __init__(self, simulation, name, solvers, data=None):
         """Create equation object

--- a/pyelmer/test/test_elmer.py
+++ b/pyelmer/test/test_elmer.py
@@ -1,6 +1,7 @@
 import yaml
 import filecmp
 import gmsh
+import pytest
 import os
 import re
 import tempfile
@@ -228,6 +229,127 @@ def test_load_initial_condition():
         ).get_data()
         == data
     )
+
+
+def test_duplicate_body():
+    sim = elmer.Simulation()
+
+    obj1 = elmer.Body(sim, "duplicate", body_ids=[1], data={"test": 7})
+    obj2 = elmer.Body(sim, "duplicate", body_ids=[1], data={"test": 7})
+    assert obj1 == obj2
+
+    obj3 = elmer.Body(sim, "different")
+    assert obj1 != obj3
+
+    with pytest.raises(ValueError):
+        elmer.Body(sim, "duplicate", body_ids=[1])
+
+    with pytest.raises(ValueError):
+        elmer.Body(sim, "duplicate", data={"test": 7})
+
+
+def test_duplicate_boundary():
+    sim = elmer.Simulation()
+
+    obj1 = elmer.Boundary(sim, "duplicate", geo_ids=[1], data={"test": 7})
+    obj2 = elmer.Boundary(sim, "duplicate", geo_ids=[1], data={"test": 7})
+    assert obj1 == obj2
+
+    obj3 = elmer.Boundary(sim, "different")
+    assert obj1 != obj3
+
+    with pytest.raises(ValueError):
+        elmer.Boundary(sim, "duplicate", geo_ids=[1])
+
+    with pytest.raises(ValueError):
+        elmer.Boundary(sim, "duplicate", data={"test": 7})
+
+
+def test_duplicate_material():
+    sim = elmer.Simulation()
+
+    obj1 = elmer.Material(sim, "duplicate", data={"test": 7})
+    obj2 = elmer.Material(sim, "duplicate", data={"test": 7})
+    assert obj1 == obj2
+
+    obj3 = elmer.Material(sim, "different")
+    assert obj1 != obj3
+
+    with pytest.raises(ValueError):
+        elmer.Material(sim, "duplicate")
+
+    with pytest.raises(ValueError):
+        elmer.Material(sim, "duplicate", data={"test": 8})
+
+
+def test_duplicate_body_force():
+    sim = elmer.Simulation()
+
+    obj1 = elmer.BodyForce(sim, "duplicate", data={"test": 7})
+    obj2 = elmer.BodyForce(sim, "duplicate", data={"test": 7})
+    assert obj1 == obj2
+
+    obj3 = elmer.BodyForce(sim, "different")
+    assert obj1 != obj3
+
+    with pytest.raises(ValueError):
+        elmer.BodyForce(sim, "duplicate")
+
+    with pytest.raises(ValueError):
+        elmer.BodyForce(sim, "duplicate", data={"test": 8})
+
+
+def test_duplicate_initial_condition():
+    sim = elmer.Simulation()
+
+    obj1 = elmer.InitialCondition(sim, "duplicate", data={"test": 7})
+    obj2 = elmer.InitialCondition(sim, "duplicate", data={"test": 7})
+    assert obj1 == obj2
+
+    obj3 = elmer.InitialCondition(sim, "different")
+    assert obj1 != obj3
+
+    with pytest.raises(ValueError):
+        elmer.InitialCondition(sim, "duplicate")
+
+    with pytest.raises(ValueError):
+        elmer.InitialCondition(sim, "duplicate", data={"test": 8})
+
+
+def test_duplicate_solver():
+    sim = elmer.Simulation()
+
+    obj1 = elmer.Solver(sim, "duplicate", data={"test": 7})
+    obj2 = elmer.Solver(sim, "duplicate", data={"test": 7})
+    assert obj1 == obj2
+
+    obj3 = elmer.Solver(sim, "different")
+    assert obj1 != obj3
+
+    with pytest.raises(ValueError):
+        elmer.Solver(sim, "duplicate")
+
+    with pytest.raises(ValueError):
+        elmer.Solver(sim, "duplicate", data={"test": 8})
+
+
+def test_duplicate_equation():
+    sim = elmer.Simulation()
+    solver1 = elmer.Solver(sim, "solver1")
+    solver2 = elmer.Solver(sim, "solver2")
+
+    obj1 = elmer.Equation(sim, "duplicate", [solver1], data={"test": 7})
+    obj2 = elmer.Equation(sim, "duplicate", [solver1], data={"test": 7})
+    assert obj1 == obj2
+
+    obj3 = elmer.Equation(sim, "different", [solver1])
+    assert obj1 != obj3
+
+    with pytest.raises(ValueError):
+        elmer.Equation(sim, "duplicate", [solver1])
+
+    with pytest.raises(ValueError):
+        elmer.Equation(sim, "duplicate", [solver2], data={"test": 7})
 
 
 def test_write_sif():

--- a/pyelmer/test/test_elmer.py
+++ b/pyelmer/test/test_elmer.py
@@ -238,10 +238,10 @@ def test_duplicate_body():
 
     obj1 = elmer.Body(sim, "duplicate", body_ids=[1], data={"test": 7})
     obj2 = elmer.Body(sim, "duplicate", body_ids=[1], data={"test": 7})
-    assert obj1 == obj2
+    assert obj1 is obj2
 
     obj3 = elmer.Body(sim, "different")
-    assert obj1 != obj3
+    assert obj1 is not obj3
 
     with pytest.raises(ValueError):
         elmer.Body(sim, "duplicate", body_ids=[1])
@@ -255,10 +255,10 @@ def test_duplicate_boundary():
 
     obj1 = elmer.Boundary(sim, "duplicate", geo_ids=[1], data={"test": 7})
     obj2 = elmer.Boundary(sim, "duplicate", geo_ids=[1], data={"test": 7})
-    assert obj1 == obj2
+    assert obj1 is obj2
 
     obj3 = elmer.Boundary(sim, "different")
-    assert obj1 != obj3
+    assert obj1 is not obj3
 
     with pytest.raises(ValueError):
         elmer.Boundary(sim, "duplicate", geo_ids=[1])
@@ -272,10 +272,10 @@ def test_duplicate_material():
 
     obj1 = elmer.Material(sim, "duplicate", data={"test": 7})
     obj2 = elmer.Material(sim, "duplicate", data={"test": 7})
-    assert obj1 == obj2
+    assert obj1 is obj2
 
     obj3 = elmer.Material(sim, "different")
-    assert obj1 != obj3
+    assert obj1 is not obj3
 
     with pytest.raises(ValueError):
         elmer.Material(sim, "duplicate")
@@ -289,10 +289,10 @@ def test_duplicate_body_force():
 
     obj1 = elmer.BodyForce(sim, "duplicate", data={"test": 7})
     obj2 = elmer.BodyForce(sim, "duplicate", data={"test": 7})
-    assert obj1 == obj2
+    assert obj1 is obj2
 
     obj3 = elmer.BodyForce(sim, "different")
-    assert obj1 != obj3
+    assert obj1 is not obj3
 
     with pytest.raises(ValueError):
         elmer.BodyForce(sim, "duplicate")
@@ -306,10 +306,10 @@ def test_duplicate_initial_condition():
 
     obj1 = elmer.InitialCondition(sim, "duplicate", data={"test": 7})
     obj2 = elmer.InitialCondition(sim, "duplicate", data={"test": 7})
-    assert obj1 == obj2
+    assert obj1 is obj2
 
     obj3 = elmer.InitialCondition(sim, "different")
-    assert obj1 != obj3
+    assert obj1 is not obj3
 
     with pytest.raises(ValueError):
         elmer.InitialCondition(sim, "duplicate")
@@ -323,10 +323,10 @@ def test_duplicate_solver():
 
     obj1 = elmer.Solver(sim, "duplicate", data={"test": 7})
     obj2 = elmer.Solver(sim, "duplicate", data={"test": 7})
-    assert obj1 == obj2
+    assert obj1 is obj2
 
     obj3 = elmer.Solver(sim, "different")
-    assert obj1 != obj3
+    assert obj1 is not obj3
 
     with pytest.raises(ValueError):
         elmer.Solver(sim, "duplicate")
@@ -342,10 +342,10 @@ def test_duplicate_equation():
 
     obj1 = elmer.Equation(sim, "duplicate", [solver1], data={"test": 7})
     obj2 = elmer.Equation(sim, "duplicate", [solver1], data={"test": 7})
-    assert obj1 == obj2
+    assert obj1 is obj2
 
     obj3 = elmer.Equation(sim, "different", [solver1])
-    assert obj1 != obj3
+    assert obj1 is not obj3
 
     with pytest.raises(ValueError):
         elmer.Equation(sim, "duplicate", [solver1])

--- a/pyelmer/test/test_elmer.py
+++ b/pyelmer/test/test_elmer.py
@@ -8,12 +8,12 @@ import tempfile
 from objectgmsh import add_physical_group, get_boundaries_in_box
 from pyelmer import elmer
 
-elmer.data_dir = "./test_data"
+elmer.data_dir = os.path.join(os.getcwd(), "test_data")
 
 ###############
 # set up working directory
 file_dir = os.path.dirname(__file__)
-sim_dir = file_dir + "/test_simdata"
+sim_dir = os.path.join(file_dir, "test_simdata")
 
 if not os.path.exists(sim_dir):
     os.mkdir(sim_dir)
@@ -163,7 +163,7 @@ def test_load_simulation():
         settings = yaml.safe_load(f)["test_simulation"]
     assert (
         elmer.load_simulation(
-            "test_simulation", file_dir + "/test_data/simulations.yml"
+            "test_simulation", os.path.join(file_dir, "test_data", "simulations.yml")
         ).settings
         == settings
     )
@@ -175,7 +175,7 @@ def test_load_material():
     sim = elmer.Simulation()
     assert (
         elmer.load_material(
-            "test_material", sim, file_dir + "/test_data/materials.yml"
+            "test_material", sim, os.path.join(file_dir, "test_data", "materials.yml")
         ).get_data()
         == data
     )
@@ -187,7 +187,7 @@ def test_load_solver():
     sim = elmer.Simulation()
     assert (
         elmer.load_solver(
-            "test_solver", sim, file_dir + "/test_data/solvers.yml"
+            "test_solver", sim, os.path.join(file_dir, "test_data", "solvers.yml")
         ).get_data()
         == data
     )
@@ -199,7 +199,9 @@ def test_load_body_force():
     sim = elmer.Simulation()
     assert (
         elmer.load_body_force(
-            "test_body_force", sim, file_dir + "/test_data/body_forces.yml"
+            "test_body_force",
+            sim,
+            os.path.join(file_dir, "test_data", "body_forces.yml")
         ).get_data()
         == data
     )
@@ -210,7 +212,7 @@ def test_load_boundary():
         data = yaml.safe_load(f)["test_boundary"]
     sim = elmer.Simulation()
     assert elmer.load_boundary(
-        "test_boundary", sim, file_dir + "/test_data/boundaries.yml"
+        "test_boundary", sim, os.path.join(file_dir, "test_data", "boundaries.yml")
     ).get_data() == {
         "Target Boundaries(0)": "",
         "test_parameter": data["test_parameter"],
@@ -225,7 +227,7 @@ def test_load_initial_condition():
         elmer.load_initial_condition(
             "test_initial_condition",
             sim,
-            file_dir + "/test_data/initial_conditions.yml",
+            os.path.join(file_dir, "test_data", "initial_conditions.yml"),
         ).get_data()
         == data
     )
@@ -366,32 +368,34 @@ def test_write_sif():
 
     # setup simulation
     sim = elmer.load_simulation(
-        "test_simulation", file_dir + "/test_data/simulations.yml"
+        "test_simulation", os.path.join(file_dir, "test_data", "simulations.yml")
     )
 
     test_solver = elmer.load_solver(
-        "test_solver", sim, file_dir + "/test_data/solvers.yml"
+        "test_solver", sim, os.path.join(file_dir, "test_data", "solvers.yml")
     )
 
     test_post_solver = elmer.load_solver(
-        "test_post_solver", sim, file_dir + "/test_data/solvers.yml"
+        "test_post_solver", sim, os.path.join(file_dir, "test_data", "solvers.yml")
     )
 
     test_eqn = elmer.Equation(sim, "test_equation", [test_solver])
 
     test_initial_condtion = elmer.load_initial_condition(
-        "test_initial_condition", sim, file_dir + "/test_data/initial_conditions.yml"
+        "test_initial_condition",
+        sim,
+        os.path.join(file_dir, "test_data", "initial_conditions.yml")
     )
 
     test_body_force = elmer.load_body_force(
-        "test_body_force", sim, file_dir + "/test_data/body_forces.yml"
+        "test_body_force", sim, os.path.join(file_dir, "test_data", "body_forces.yml")
     )
     # setup body object
     test_body = elmer.Body(sim, "test_body", [ph_test_body])
 
     # initialize body data
     test_material = elmer.load_material(
-        "test_material", sim, file_dir + "/test_data/materials.yml"
+        "test_material", sim, os.path.join(file_dir, "test_data", "materials.yml")
     )
     test_body.material = test_material
     test_body.initial_condition = test_initial_condtion


### PR DESCRIPTION
The current behaviour if the user tries to add two components with the same name is that the first one is silently lost, and any references to it in the SIF end up containing IDs of `0`, which Elmer isn't very happy with.

This pull request:
* Checks to see if a duplicate component already exists, and if so, returns the existing one instead of creating a new one
* Raises an exception if there is a name conflict but the data fields are not identical

I was running into this issue with `Material`s, but I added the check to all components.