### PR TITLE
chore: replace deprecated `delim_whitespace` arg with recommended update from upstream

### DIFF
--- a/pyelmer/post.py
+++ b/pyelmer/post.py
@@ -257,4 +257,4 @@ def dat_to_dataframe(dat_file):
             or "Variables in columns of matrix" in line
         ):
             names_start = True
-    return pd.read_table(dat_file, names=names, delim_whitespace=True)
+    return pd.read_table(dat_file, names=names, sep='\s+')


### PR DESCRIPTION
`delim_whitespace` is scheduled for deprecation upstream and currently spams warnings, this is the [recommended change](https://pandas.pydata.org/docs/reference/api/pandas.read_table.html).