### PR TITLE
Fix syntax warning

### DIFF
--- a/pyelmer/post.py
+++ b/pyelmer/post.py
@@ -1,9 +1,9 @@
 import os
 import re
-import numpy as np
+from dataclasses import dataclass, field
+
 import matplotlib.pyplot as plt
 import pandas as pd
-from dataclasses import dataclass, field
 
 
 @dataclass
@@ -250,11 +250,11 @@ def dat_to_dataframe(dat_file):
     names = []
     names_start = False
     for line in lines:
-        if names_start == True:
+        if names_start:
             names.append(":".join(line.split(":")[1:]).strip())
         if (
             "Data on different columns" in line
             or "Variables in columns of matrix" in line
         ):
             names_start = True
-    return pd.read_table(dat_file, names=names, sep='\s+')
+    return pd.read_table(dat_file, names=names, sep=r"\s+")


### PR DESCRIPTION
I'm getting the following warning using `pyelmer` with Python 3.12:

`/home/.venv/lib/python3.12/site-packages/pyelmer/post.py:260: SyntaxWarning: invalid escape sequence '\s'
  return pd.read_table(dat_file, names=names, sep='\s+')`

Using a raw string literal instead gets rid of that warning.

I have also removed the unused `numpy` import in the `post` module and updated the check of a boolean variable.